### PR TITLE
Rule fixes post scratch-vm review

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,8 @@ module.exports = {
         'space-before-function-paren': [2, 'always'],
         'space-in-parens': [2],
         'space-infix-ops': [2],
-        'space-unary-ops': [2]
+        'space-unary-ops': [2],
+        'spaced-comment': [2]
     },
     env: {
         commonjs: true

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ module.exports = {
 
         // Style
         'array-bracket-spacing': [2, 'never'],
+        'block-spacing': [2, 'always'],
         'brace-style': [2],
         'camelcase': [2],
         'comma-dangle': [2, 'never'],

--- a/index.js
+++ b/index.js
@@ -120,7 +120,8 @@ module.exports = {
         'semi': [2, 'always'],
         'semi-spacing': [2],
         'space-before-function-paren': [2, 'always'],
-        'space-in-parens': [2]
+        'space-in-parens': [2],
+        'space-infix-ops': [2]
     },
     env: {
         commonjs: true

--- a/index.js
+++ b/index.js
@@ -72,6 +72,7 @@ module.exports = {
         'brace-style': [2],
         'camelcase': [2],
         'comma-dangle': [2, 'never'],
+        'comma-spacing': [2],
         'func-style': [2, 'expression'],
         'indent': [2, 4],
         'jsx-quotes': [2, 'prefer-double'],

--- a/index.js
+++ b/index.js
@@ -121,7 +121,8 @@ module.exports = {
         'semi-spacing': [2],
         'space-before-function-paren': [2, 'always'],
         'space-in-parens': [2],
-        'space-infix-ops': [2]
+        'space-infix-ops': [2],
+        'space-unary-ops': [2]
     },
     env: {
         commonjs: true

--- a/index.js
+++ b/index.js
@@ -119,7 +119,8 @@ module.exports = {
         'require-jsdoc': [1],
         'semi': [2, 'always'],
         'semi-spacing': [2],
-        'space-before-function-paren': [2, 'always']
+        'space-before-function-paren': [2, 'always'],
+        'space-in-parens': [2]
     },
     env: {
         commonjs: true

--- a/index.js
+++ b/index.js
@@ -70,7 +70,9 @@ module.exports = {
         'array-bracket-spacing': [2, 'never'],
         'block-spacing': [2, 'always'],
         'brace-style': [2],
-        'camelcase': [2],
+        'camelcase': [2, {
+            properties: 'never'
+        }],
         'comma-dangle': [2, 'never'],
         'comma-spacing': [2],
         'comma-style': [2],

--- a/index.js
+++ b/index.js
@@ -67,6 +67,7 @@ module.exports = {
         'strict': [2, 'never'],
 
         // Style
+        'array-bracket-spacing': [2, 'never'],
         'brace-style': [2],
         'camelcase': [2],
         'comma-dangle': [2, 'never'],

--- a/index.js
+++ b/index.js
@@ -73,6 +73,7 @@ module.exports = {
         'camelcase': [2],
         'comma-dangle': [2, 'never'],
         'comma-spacing': [2],
+        'comma-style': [2],
         'func-style': [2, 'expression'],
         'indent': [2, 4],
         'jsx-quotes': [2, 'prefer-double'],

--- a/index.js
+++ b/index.js
@@ -75,6 +75,7 @@ module.exports = {
         'comma-spacing': [2],
         'comma-style': [2],
         'eol-last': [2, 'always'],
+        'func-call-spacing': [2, 'never'],
         'func-style': [2, 'expression'],
         'indent': [2, 4],
         'jsx-quotes': [2, 'prefer-double'],

--- a/index.js
+++ b/index.js
@@ -108,9 +108,10 @@ module.exports = {
         }],
         'one-var': [2, 'never'],
         'operator-linebreak': [2, 'after'],
+        'quote-props': [2, 'consistent-as-needed'],
         'quotes': [2, 'single', {
-            'allowTemplateLiterals': true,
-            'avoidEscape': true
+            allowTemplateLiterals: true,
+            avoidEscape: true
         }],
         'require-jsdoc': [1],
         'semi': [2, 'always'],

--- a/index.js
+++ b/index.js
@@ -74,6 +74,7 @@ module.exports = {
         'comma-dangle': [2, 'never'],
         'comma-spacing': [2],
         'comma-style': [2],
+        'eol-last': [2, 'always'],
         'func-style': [2, 'expression'],
         'indent': [2, 4],
         'jsx-quotes': [2, 'prefer-double'],

--- a/index.js
+++ b/index.js
@@ -103,8 +103,9 @@ module.exports = {
         }],
         'no-negated-condition': [1],
         'no-tabs': [2],
-        'no-trailing-spaces': [2, { skipBlankLines: true }],
+        'no-trailing-spaces': [2, {skipBlankLines: true}],
         'no-unneeded-ternary': [2],
+        'object-curly-spacing': [2],
         'object-property-newline': [2, {
             allowMultiplePropertiesPerLine: true
         }],

--- a/index.js
+++ b/index.js
@@ -117,6 +117,7 @@ module.exports = {
         }],
         'require-jsdoc': [1],
         'semi': [2, 'always'],
+        'semi-spacing': [2],
         'space-before-function-paren': [2, 'always']
     },
     env: {

--- a/node.js
+++ b/node.js
@@ -6,5 +6,8 @@ module.exports = {
         'no-mixed-requires': [2],
         'no-new-require': [2],
         'no-path-concat': [2]
+    },
+    env: {
+        node: true
     }
 };


### PR DESCRIPTION
This adds the whitespace rules @thisandagain pointed out in https://github.com/LLK/scratch-vm/pull/298.

I missed a lot of whitespace-related rules because I mistook the "autofix" symbol on http://eslint.org/docs/rules/ for the "included in eslint/recommended" symbol.  So I added the ones that make sense for us (we already adhere to them in scratch-vm).

One more worth pointing out is `'quote-props': [2, 'consistent-as-needed']`: Object properties should not use quotes unless necessary, in which case all properties of the object should use quotes.

After I added and fixed this in scratch-vm, it pointed out I was too strict with the camelcase rule, so that now excludes object properties from needing to be camelcase (we use many underscores in object properties in scratch-vm).
