### PR TITLE
fix(es6): Allow rest/spread syntax

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -18,5 +18,10 @@ module.exports = {
     },
     env: {
         es6: true
+    },
+    parserOptions: {
+        ecmaFeatures: {
+            experimentalObjectRestSpread: true
+        }
     }
 };


### PR DESCRIPTION
Previously the parser didn't recognize rest/spread syntax as valid