### PR TITLE
chore(windows): Add .gitattributes with *.js rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
Since `eslint` requires LF-only line endings and the default git config on Windows uses CRLF for text files, this `.gitattributes` rule is necessary for `npm test` / `eslint` to pass on most Windows systems.