### PR TITLE
feat(reat,es6,node,base,deps): Move all warnings to errors

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -9,9 +9,9 @@ module.exports = {
         'no-confusing-arrow': [2],
         'no-useless-computed-key': [2],
         'no-useless-constructor': [2],
-        'no-var': [1],
+        'no-var': [2],
         'prefer-arrow-callback': [2],
-        'prefer-const': [1, {destructuring: 'all'}],
+        'prefer-const': [2, {destructuring: 'all'}],
         'prefer-template': [2],
         'rest-spread-spacing': [2, 'never'],
         'template-curly-spacing': [2, 'never']

--- a/index.js
+++ b/index.js
@@ -23,19 +23,19 @@ module.exports = {
         }],
 
         // Best practices
-        'array-callback-return': [1],
-        'block-scoped-var': [1],
+        'array-callback-return': [2],
+        'block-scoped-var': [2],
         'curly': [2, 'multi-line'],
         'dot-location': [2, 'property'],
         'dot-notation': [2],
         'eqeqeq': [2],
         'no-alert': [2],
         'no-div-regex': [2],
-        'no-else-return': [1],
+        'no-else-return': [2],
         'no-eq-null': [2],
         'no-eval': [2],
         'no-extend-native': [2],
-        'no-extra-bind': [1],
+        'no-extra-bind': [2],
         'no-global-assign': [2],
         'no-implied-eval': [2],
         'no-invalid-this': [2],
@@ -44,22 +44,17 @@ module.exports = {
         'no-loop-func': [2],
         'no-multi-spaces': [2],
         'no-multi-str': [2],
-        'no-new': [1],
+        'no-new': [2],
         'no-proto': [2],
-        'no-restricted-properties': [1, {
-            object: 'lodash',
-            property: 'defaults',
-            message: 'Please use Object.assign'
-        }],
         'no-return-assign': [2],
         'no-script-url': [2],
         'no-self-compare': [2],
-        'no-sequences': [1],
+        'no-sequences': [2],
         'no-throw-literal': [2],
-        'no-unmodified-loop-condition': [1],
+        'no-unmodified-loop-condition': [2],
         'no-unused-expressions': [2],
         'no-useless-call': [2],
-        'no-useless-concat': [1],
+        'no-useless-concat': [2],
         'no-useless-escape': [2],
         'no-warning-comments': [1, {
             location: 'anywhere'
@@ -75,7 +70,7 @@ module.exports = {
         'no-shadow': [2],
         'no-undefined': [2],
         'no-use-before-define': [2],
-        
+
         // Strict
         'strict': [2, 'never'],
 
@@ -111,14 +106,14 @@ module.exports = {
         }],
         'new-parens': [2],
         'newline-per-chained-call': [2],
-        'no-lonely-if': [1],
-        'no-mixed-operators': [1],
+        'no-lonely-if': [2],
+        'no-mixed-operators': [2],
         'no-multiple-empty-lines': [2, {
             max: 2,
             maxBOF: 0,
             maxEOF: 0
         }],
-        'no-negated-condition': [1],
+        'no-negated-condition': [2],
         'no-tabs': [2],
         'no-trailing-spaces': [2, {skipBlankLines: true}],
         'no-unneeded-ternary': [2],
@@ -133,7 +128,7 @@ module.exports = {
             allowTemplateLiterals: true,
             avoidEscape: true
         }],
-        'require-jsdoc': [1],
+        'require-jsdoc': [2],
         'semi': [2, 'always'],
         'semi-spacing': [2],
         'space-before-function-paren': [2, 'always'],

--- a/node.js
+++ b/node.js
@@ -2,7 +2,7 @@ module.exports = {
     rules: {
         // Node/CommonJS
         'global-require': [2],
-        'handle-callback-err': [1],
+        'handle-callback-err': [2],
         'no-mixed-requires': [2],
         'no-new-require': [2],
         'no-path-concat': [2]

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
     "scratch"
   ],
   "optionalDependencies": {
-    "eslint-plugin-react": "6.x"
+    "eslint-plugin-react": "7.x"
   },
   "peerDependencies": {
     "babel-eslint": "7.x",
-    "eslint": "3.x"
+    "eslint": "4.x"
   },
   "devDependencies": {
-    "babel-eslint": "^7.0.0",
+    "babel-eslint": "^7.2.3",
     "cz-conventional-changelog": "1.2.0",
-    "eslint": "^3.8.1",
+    "eslint": "^4.4.1",
     "semantic-release": "^4.3.5"
   },
   "config": {

--- a/react.js
+++ b/react.js
@@ -16,12 +16,12 @@ module.exports = {
         }],
         'react/no-render-return-value': [2],
         'react/no-set-state': [0],
-        'react/no-string-refs': [1],
+        'react/no-string-refs': [2],
         'react/no-unescaped-entities': [2],
         'react/no-unknown-property': [2],
         'react/no-unused-prop-types': [2],
         'react/prefer-es6-class': [2],
-        'react/prefer-stateless-function': [1],
+        'react/prefer-stateless-function': [2],
         'react/prop-types': [2],
         'react/react-in-jsx-scope': [2],
         'react/require-optimization': [0],
@@ -43,7 +43,7 @@ module.exports = {
         'react/jsx-indent-props': [2],
         'react/jsx-key': [2],
         'react/jsx-max-props-per-line': [2, {maximum: 1}],
-        'react/jsx-no-bind': [1, {
+        'react/jsx-no-bind': [2, {
             ignoreRefs: true
         }],
         'react/jsx-no-comment-textnodes': [2],


### PR DESCRIPTION
Make all previous warning rules into errors except the todo rule

Fixes #11, breaking change include eslint4.0 and other dep updates, and all rule changes

See https://github.com/LLK/eslint-config-scratch/issues/11#issue-249406530 for discussion about the update. 

@rschamp @cwillisf i'm not familiar with the way this repo handles versioning, so I just followed the instructions from the README. Hopefully I did it right. 🌮  You might want to double check the dependency updates, those were done manually to the most recent releases. 