### PR TITLE
fix(react): Migrate jsx-space-before-closing to jsx-tag-spacing

### DIFF
--- a/react.js
+++ b/react.js
@@ -57,7 +57,7 @@ module.exports = {
             shorthandFirst: true,
             callbacksLast: true
         }],
-        'react/jsx-space-before-closing': [2, 'always'],
+        'react/jsx-tag-spacing': [2],
         'react/jsx-uses-react': [2],
         'react/jsx-uses-vars': [2],
         'react/jsx-wrap-multilines': [2]


### PR DESCRIPTION
Fix a deprecation warning and move our jsx-space-before-closing rule to jsx-tag-spacing instead (our preference is the default)