### PR TITLE
chore(dependencies): Update dependencies, use ^ syntax for peer, optional deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "scratch"
   ],
   "optionalDependencies": {
-    "eslint-plugin-react": "7.x"
+    "eslint-plugin-react": "^7.0"
   },
   "peerDependencies": {
-    "babel-eslint": "7.x",
-    "eslint": "4.x"
+    "babel-eslint": "^8.0.1",
+    "eslint": "^4.0"
   },
   "devDependencies": {
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "8.0.1",
     "cz-conventional-changelog": "1.2.0",
     "eslint": "^4.4.1",
     "semantic-release": "^4.3.5"


### PR DESCRIPTION
Update `babel-eslint` so downstream packages can update without a peer dependency warning

BREAKING CHANGE: must update `babel-eslint` peer dependency
Resolves #15