### PR TITLE
Remove prop sort

### DIFF
--- a/react.js
+++ b/react.js
@@ -28,7 +28,6 @@ module.exports = {
         'react/require-render-return': [2],
         'react/self-closing-comp': [2],
         'react/sort-comp': [2],
-        'react/sort-prop-types': [2],
         'react/style-prop-object': [2],
 
         // JSX
@@ -52,10 +51,6 @@ module.exports = {
         'react/jsx-no-undef': [2],
         'react/jsx-pascal-case': [2, {
             allowAllCaps: true
-        }],
-        'react/jsx-sort-props': [2, {
-            shorthandFirst: true,
-            callbacksLast: true
         }],
         'react/jsx-tag-spacing': [2],
         'react/jsx-uses-react': [2],


### PR DESCRIPTION
On this set of props:
```
    onCopyToClipboard: PropTypes.func.isRequired,
    onGroup: PropTypes.func.isRequired,
    onPasteFromClipboard: PropTypes.func.isRequired,
    onRedo: PropTypes.func.isRequired,
    onSendBackward: PropTypes.func.isRequired,
    onSendForward: PropTypes.func.isRequired,
    onSendToBack: PropTypes.func.isRequired,
    onSendToFront: PropTypes.func.isRequired,
    onUndo: PropTypes.func.isRequired,
    onUngroup: PropTypes.func.isRequired,
```

it's most common that you would be working with 'onGroup' and 'onUngroup' at the same time, or 'onUndo'/'onRedo', or 'onCopy'/'onPaste', but they are far apart. I think this makes a lot less sense than the alphabetical ordering adds.

It seems like the cost of having to search through the list for the right alphabetical placement is not worth the savings in time searching through the list of props to be able to find something later, since we don't seem to need to do that often. (It might make more sense if this were fixed automatically instead of giving an error?)