### PR TITLE
Replace experimentalObjectRestSpread with ecmaVersion: 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
 notifications:
   email: false
 node_js:
-  - '4'
+  - 10
 before_install:
   - npm i -g npm@^2.0.0
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ notifications:
 node_js:
   - 10
 before_install:
-  - npm i -g npm@^2.0.0
+  - npm install -g npm@latest
 before_script:
   - npm prune
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,6 @@ notifications:
   email: false
 node_js:
   - 10
-before_install:
-  - npm install -g npm@latest
 before_script:
   - npm prune
 after_success:

--- a/es6.js
+++ b/es6.js
@@ -20,8 +20,6 @@ module.exports = {
         es6: true
     },
     parserOptions: {
-        ecmaFeatures: {
-            experimentalObjectRestSpread: true
-        }
+        ecmaVersion: 2018
     }
 };

--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
     "scratch"
   ],
   "optionalDependencies": {
-    "eslint-plugin-react": "^7.0"
+    "eslint-plugin-react": ">=7.0.0"
   },
   "peerDependencies": {
-    "babel-eslint": "^8.0.1",
-    "eslint": "^4.0"
+    "babel-eslint": ">=8.0.1",
+    "eslint": ">=4.0.0"
   },
   "devDependencies": {
     "babel-eslint": "8.0.1",
     "cz-conventional-changelog": "1.2.0",
-    "eslint": "^4.4.1",
+    "eslint": "^5.0.0",
     "semantic-release": "^4.3.5"
   },
   "config": {


### PR DESCRIPTION
https://github.com/tc39/proposal-object-rest-spread has become a part
of the ECMAScript standard as of version 2018 (also known as ECMAScript
9).

experimentalObjectRestSpread will be [removed in the future](https://eslint.org/docs/user-guide/configuring#deprecated) from eslint.

This resolves the deprecation message displayed by current eslint.

> (node:43587) [ESLINT_LEGACY_OBJECT_REST_SPREAD] DeprecationWarning: The 'parserOptions.ecmaFeatures.experimentalObjectRestSpread' option is deprecated. Use 'parserOptions.ecmaVersion' instead. (found in "scratch/es6")