### PR TITLE
feat(es6): enable several new ES6 rules and update eslint dep

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -7,13 +7,23 @@ module.exports = {
             after: true
         }],
         'no-confusing-arrow': [2],
+        'no-duplicate-imports': [2],
+        'no-return-await': [2],
+        'no-template-curly-in-string': [2],
         'no-useless-computed-key': [2],
         'no-useless-constructor': [2],
+        'no-useless-rename': [2],
         'no-var': [2],
         'prefer-arrow-callback': [2],
         'prefer-const': [2, {destructuring: 'all'}],
+        'prefer-promise-reject-errors': [2],
+        'prefer-rest-params': [2],
+        'prefer-spread': [2],
         'prefer-template': [2],
+        'require-atomic-updates': [2],
+        'require-await': [2],
         'rest-spread-spacing': [2, 'never'],
+        'symbol-description': [2],
         'template-curly-spacing': [2, 'never']
     },
     env: {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "babel-eslint": ">=8.0.1",
-    "eslint": ">=4.0.0"
+    "eslint": ">=5.3.0"
   },
   "devDependencies": {
     "babel-eslint": "10.0.3",


### PR DESCRIPTION
BREAKING CHANGE: Enable several rules related to ES6 features, mostly promises and async/await but a few other features as well.

One of these rules, 'require-atomic-updates', was introduced in ESLint 5.3.0 so that's now the minimum specified in peerDependencies.

Link to rule docs, for convenience: <https://eslint.org/docs/rules/>

Examples for the new rules:

### no-duplicate-imports
```diff
-import {thing1} from 'somewhere';
+import {thing1, thing2} from 'somewhere';
 import {other} from 'elsewhere';
-import {thing2} from 'somewhere';
```

###  no-return-await
```diff
 async function foo() {
   // do some other async stuff
-  return await other();
+  return other();
 }
```

In almost all cases these two do have the same effect from the caller's perspective, though `return await` can have a small performance hit.

### no-template-curly-in-string
```diff
-const myString = "a ${placeholder} probably means the string should be a template";
+const myString = `a ${placeholder} probably means the string should be a template`;
```

### no-useless-rename
```diff
-import {foo as foo} from "bar";
+import {foo} from "bar";
```

### prefer-promise-reject-errors
```diff
-Promise.reject("oof");
+Promise.reject(new Error("oof"));
```
This means we can get a stack trace in a debugger. It also helps emphasize that rejecting a promise is the async version of throwing an exception, which I didn't understand when I first started working with promises. See also `scratch-storage` headaches...

### prefer-rest-params
```diff
-function foo(fixedArg) {
+function foo(fixedArg, ...otherArgsArray) {
-  const otherArgsArray = Array.prototype.slice.call(arguments, 1);
   doThingsWith(fixedArg, otherArgsArray);
```

### prefer-spread
```diff
 const numbers = [1, 2, 3, 4, 5];
-const maxNum = Math.max.apply(Math, args);
+const maxNum = Math.max(...numbers);
```

### require-atomic-updates
```diff
 async function calculateTotalSomething() {
   let total = 0;
   for (...) {
-    total += await calculateSingleSomething(...);
+    const thisSomething = await calculateSingleSomething(...);
+    total += thisSomething;
   }
   return total;
 }
```

This one's pretty subtle, and maybe we're unlikely to run into this issue, but if we do I think this rule could save a lot of headache. Basically, the `total += await` line doesn't do what you expect and you'll end up with a wrong answer. For a full explanation see the docs here: <https://eslint.org/docs/rules/require-atomic-updates>

### require-await
```diff
-async function notActuallyAsync() {
+function notActuallyAsync() {
   doSomethingSynchronous();
   return 42;
}
```

This complains if you have an async function which doesn't use `await`. Most likely it means you forgot an `await` somewhere or you refactored an async function such that it no longer needs to be async.

### symbol-description
```diff
-const mySymbol = Symbol();
+const mySymbol = Symbol('a symbol used as an example');
```

This is just an aid for debugging and maybe readability.