### PR TITLE
added no-prototype-builtins rule, set to error

### DIFF
--- a/es6.js
+++ b/es6.js
@@ -6,6 +6,7 @@ module.exports = {
             before: true,
             after: true
         }],
+        'no-prototype-builtins': [2],
         'no-confusing-arrow': [2],
         'no-duplicate-imports': [2],
         'no-return-await': [2],


### PR DESCRIPTION
"no-prototype-builtins" is a relatively new eslint rule, which we want to take seriously.

It seems that we need to replace all instances of `obj1.hasOwnProperty(propName)` with `Object.prototype.hasOwnProperty.call(obj1, propName)`.

This is blocked on updating as many repos as we can to obey this rule, before we switch it on.