### PR TITLE
feat(react): allow deprecated react methods and update eslint dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "babel-eslint": ">=8.0.1",
-    "eslint": ">=5.3.0"
+    "eslint": ">=5.7.0"
   },
   "devDependencies": {
     "babel-eslint": "10.0.3",

--- a/react.js
+++ b/react.js
@@ -55,7 +55,10 @@ module.exports = {
         'react/jsx-tag-spacing': [2],
         'react/jsx-uses-react': [2],
         'react/jsx-uses-vars': [2],
-        'react/jsx-wrap-multilines': [2]
+        'react/jsx-wrap-multilines': [2],
+
+        // Allow deprecated lifecycle methods
+        'camelcase': [2, {allow: ['^UNSAFE_']}]
     },
     plugins: ['react'],
     extends: ['plugin:react/recommended']


### PR DESCRIPTION
BREAKING CHANGE: The change to the camelcase rule requires ESLint 5.7.0
so that's now the minimum specified in peerDependencies.

Link to rule docs about camelcase, for convenience: https://eslint.org/docs/rules/camelcase#allow

When using `scratch/react` eslint config, you are now allowed to have non-camelcased method names as long as they start with `UNSAFE_` to match the format of deprecated lifecycle methods deprecated in React 16.3 [See here for more info about that.](https://reactjs.org/blog/2018/03/29/react-v-16-3.html#component-lifecycle-changes)

This is part of allowing a safe upgrade path to new React versions.
1. Update the version of eslint-config-scratch in the repo
2. Convert deprecated lifecycle methods (the react docs recommend `npx react-codemod rename-unsafe-lifecycles` to do it automatically)
3. Safely update to a newer version of React > 16.2
4. Migrate to new lifecycle methods available in React 16.3+
5. Once our repos are migrated, we can create a new version of this config to remove that rule and close the door on the deprecated features.

/cc @rschamp I'm pretty sure this counts as a breaking change / major version update because it requires an updated peer dependency, so if people try to use it without modifying their own packages.json it will break. Let me know if that isn't right.