### PR TITLE
Revert "feat(react): allow deprecated react methods and update eslint…

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "babel-eslint": ">=8.0.1",
-    "eslint": ">=5.7.0"
+    "eslint": ">=5.3.0"
   },
   "devDependencies": {
     "babel-eslint": "10.0.3",

--- a/react.js
+++ b/react.js
@@ -55,10 +55,7 @@ module.exports = {
         'react/jsx-tag-spacing': [2],
         'react/jsx-uses-react': [2],
         'react/jsx-uses-vars': [2],
-        'react/jsx-wrap-multilines': [2],
-
-        // Allow deprecated lifecycle methods
-        'camelcase': [2, {allow: ['^UNSAFE_']}]
+        'react/jsx-wrap-multilines': [2]
     },
     plugins: ['react'],
     extends: ['plugin:react/recommended']


### PR DESCRIPTION
Reverts LLK/eslint-config-scratch#76

There is a bug with this, since it did not carry over the `properties: never` rule from the base rules in `index.js`
Also, I think this is actually better done individually in the repos, since it is a temporary rule.