### PR TITLE
turn off no-warning-comments to allow TODO comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ module.exports = {
         'no-useless-call': [2],
         'no-useless-concat': [2],
         'no-useless-escape': [2],
-        'no-warning-comments': [1, {
+        'no-warning-comments': [0, {
             location: 'anywhere'
         }],
         'no-with': [2],


### PR DESCRIPTION
### Resolves
TODO comment warnings cause test failures in CircleCI

### Changes
Changes the 'no-warning-comments' rule in index.js to 0 (off) so TODO comments will no longer cause warnings.