### PR TITLE
ci: use Node LTS and npm ci, remove Greenkeeper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,10 @@
 sudo: false
 language: node_js
-cache:
-  directories:
-    - node_modules
 notifications:
   email: false
 node_js:
-  - 10
-before_install:
-- npm install -g greenkeeper-lockfile
-install: npm install
-before_script: greenkeeper-lockfile-update
-after_script: greenkeeper-lockfile-upload
+- lts/*
+install: npm ci --production=false
 after_success:
   - npx semantic-release
 branches:


### PR DESCRIPTION
### Proposed Changes

Update Travis config:

* Use Node LTS
* Use `npm ci`
* Don't cache `node_modules`
* Remove `greenkeeper-lockfile` tool

### Reason for Changes

* We should make sure our packages work with the latest LTS Node, similar to LLK/scratch-vm#3661
* We've been committing changes to `package-lock.json` since July of 2019 so we should probably use it on CI 😅
* The `node_modules` directory is deleted by `npm ci`
* We no longer use Greenkeeper

### Test Coverage

See this PR's CI build output