### PR TITLE
ci: do not run commitlint on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,10 @@ workflows:
     jobs:
       - commitlint/lint:
           target-branch: master
+          filters:
+            branches:
+                ignore:
+                  - master
   main-workflow:
     jobs:
       - main-job


### PR DESCRIPTION
### Resolves

- Resolves [ENA-199](https://scratchfoundation.atlassian.net/browse/ENA-199)

### Proposed Changes

- Skip `commitlint` on the `master` branch

### Reason for Changes

We do not want to re-write commit history on these "main" branches. Commit messages that do not follow conventional commit should be caught in other branches. However, this way the CI won't fail if they are merged to one of these branches. 

### Test Coverage

- Ran `circleci config validate` to validate the configuration

[ENA-199]: https://scratchfoundation.atlassian.net/browse/ENA-199?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ